### PR TITLE
fix(client): don't  error on 204 response

### DIFF
--- a/src/axio/session.cr
+++ b/src/axio/session.cr
@@ -43,12 +43,8 @@ module Axio
         raise Exception.new("The request-method type is invalid.")
       end
 
-      case response.status_code
-      when 200, 201, 202, 203, 204
-        return response
-      else
-        raise Exception.new("An exception occured with a status code of #{response.status_code}")
-      end
+      return response if response.success?
+      raise Exception.new("An exception occured with a status code of #{response.status_code}")
     end
 
     def get(url : String) : Halite::Response

--- a/src/axio/session.cr
+++ b/src/axio/session.cr
@@ -44,7 +44,7 @@ module Axio
       end
 
       case response.status_code
-      when 200
+      when 200, 201, 202, 203, 204
         return response
       else
         raise Exception.new("An exception occured with a status code of #{response.status_code}")


### PR DESCRIPTION
On testing with a live server, an unlock request succeeds on the server and physical lock but our client throws an error as the response code is 204 instead of 200.
`[PlaceOS][WS] [DEBUG] mod-EFQWRrAUmM → remote exception: An exception occured with a status code of 204 (Exception) `

This change treats 200-204 as successes, instead of erroring.